### PR TITLE
[DOCS-6409] Revised content and syntax for existing plugin automation.

### DIFF
--- a/src/main/resources/page.adoc
+++ b/src/main/resources/page.adoc
@@ -37,24 +37,33 @@ ${chaptersPlacement.place('after', 'prerequisites')}
 
 == Plugin configurations
 
-Plugin configurations are sets of parameters that apply
-across some or all of the plugin procedures. They
-reduce repetition of common values, create
-predefined parameter sets for end users, and
-securely store credentials where needed. Each configuration
-is given a unique name that is entered in designated
-parameters on procedures that use them.
+Plugin configurations are sets of parameters that can be applied
+across some, or all, of the plugin procedures. They
+can reduce the repetition of common values, create
+predefined parameter sets, and securely store credentials.
+Each configuration is given a unique name that is entered
+in the designated parameter for the plugin procedures that use them.
 
 
 === Creating plugin configurations
 
-To create plugin configurations in {CD}, do these steps:
+To create plugin configurations in {PRODUCT}:
 
-* Go to menu:Administration[Plugins] to open the Plugin Manager.
-* Find the @PLUGIN_NAME@ row.
-* Click *Configure* to open the
-     Configurations page.
-* Click *Create Configuration* as per the description of parameters below.
+. Navigate to menu:DevOps Essentials[Plugin Management] to open the Plugin Manager.
+
+. Select the *Configurations* tab to open the Configurations page.
+
+. Select *+* in the upper right corner to create a new configuration.
+
+. In the *New Configuration* window, specify a *Name* for the configuration.
+
+. Select the *Project* that the configuration belongs to.
+
+. Optionally, add a *Description* for the configuration.
+
+. Select the appropriate *Plugin* for the configuration.
+
+. Configure the parameters per the descriptions below.
 
 <% if (configurationProcedure.preface) { %>
 ${configurationProcedure.preface}
@@ -62,7 +71,7 @@ ${configurationProcedure.preface}
 
 === Configuration procedure parameters
 
-[cols=",",options="header"]
+[cols="1a,1a",options="header"]
 |===
 |Parameter |Description
 <% for (def field in configurationProcedure.fields) { %>
@@ -97,7 +106,7 @@ ${procedure.preface}
 <% } %>
 
 ==== ${procedure.name} parameters
-[cols=",",options="header"]
+[cols="1a,1a",options="header"]
 |===
 |Parameter |Description
 <% for (def field in procedure.fields) { %>
@@ -109,7 +118,7 @@ ${procedure.preface}
 
 ==== Output parameters
 
-[cols=",",options="header"]
+[cols="1a,1a",options="header"]
 |===
 |Parameter |Description
 <% for (def param in procedure.outputParameters) { %>

--- a/src/main/resources/page.adoc
+++ b/src/main/resources/page.adoc
@@ -52,7 +52,7 @@ To create plugin configurations in {PRODUCT}, complete these steps:
 * Go to menu:Administration[Plugins] to open the Plugin Manager.
 * Find the @PLUGIN_NAME@ row.
 * Click *Configure* to open the
-Configurations page.
+     Configurations page.
 * Click *Create Configuration* as per the description of parameters below.
 
 <% if (configurationProcedure.preface) { %>

--- a/src/main/resources/page.adoc
+++ b/src/main/resources/page.adoc
@@ -47,23 +47,13 @@ in the designated parameter for the plugin procedures that use them.
 
 === Creating plugin configurations
 
-To create plugin configurations in {PRODUCT}:
+To create plugin configurations in {PRODUCT}, complete these steps:
 
-. Navigate to menu:DevOps Essentials[Plugin Management] to open the Plugin Manager.
-
-. Select the *Configurations* tab to open the Configurations page.
-
-. Select *+* in the upper right corner to create a new configuration.
-
-. In the *New Configuration* window, specify a *Name* for the configuration.
-
-. Select the *Project* that the configuration belongs to.
-
-. Optionally, add a *Description* for the configuration.
-
-. Select the appropriate *Plugin* for the configuration.
-
-. Configure the parameters per the descriptions below.
+* Go to menu:Administration[Plugins] to open the Plugin Manager.
+* Find the @PLUGIN_NAME@ row.
+* Click *Configure* to open the
+Configurations page.
+* Click *Create Configuration* as per the description of parameters below.
 
 <% if (configurationProcedure.preface) { %>
 ${configurationProcedure.preface}


### PR DESCRIPTION
When the current automation runs, it appears to overwrite the table syntax to use the following, and preventing the tables from rendering as proper AsciiDoc. This results in additional changes in the automated PRs that are overwritten again the next time the automation runs: `[cols=",",options="header"]`

We are currently manually fixing this each time the automation runs for any plugin, since overwritten in the help.adoc file in the engineering repo.

This PR attempts to address this issue.